### PR TITLE
feat: visualize academic programs

### DIFF
--- a/src/app/core/constants/api-endpoints.constants.ts
+++ b/src/app/core/constants/api-endpoints.constants.ts
@@ -7,8 +7,15 @@ export const API_ENDPOINTS = {
     },
     FACULTY: {
         GET: '/faculty',
+        GET_TYPEAHEAD: '/faculty/typeahead',
         CREATE: '/faculty/create',
         UPDATE: (id: string) => `/faculty/update/${id}`,
         DELETE: (id: string) => `/faculty/delete/${id}`,
-    }
+    },
+    ACADEMIC_PROGRAM: {
+        GET: '/academic-programs',
+        CREATE: '/academic-programs/create',
+        UPDATE: (id: string) => `/academic-programs/update/${id}`,
+        DELETE: (id: string) => `/academic-programs/delete/${id}`,
+    },
 };

--- a/src/app/core/constants/routes.constants.ts
+++ b/src/app/core/constants/routes.constants.ts
@@ -9,6 +9,8 @@ export const ROUTES = {
     ADMIN: {
         HOME: `${ADMIN_PREFFIX}`,
         FACULTIES: `${ADMIN_PREFFIX}/faculties`,
-    }
+        ACADEMIC_PROGRAMS: `${ADMIN_PREFFIX}/academic-programs`,
+
+    },
 }
 

--- a/src/app/core/services/typeahead.service.spec.ts
+++ b/src/app/core/services/typeahead.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { TypeaheadService } from './typeahead.service';
+
+describe('TypeaheadService', () => {
+  let service: TypeaheadService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(TypeaheadService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/core/services/typeahead.service.ts
+++ b/src/app/core/services/typeahead.service.ts
@@ -1,0 +1,25 @@
+import { TypeaheadConfig, TypeaheadItem } from "@/shared/models/typeahead-item.model";
+import { Injectable } from "@angular/core";
+import { Observable } from "rxjs";
+
+@Injectable({ providedIn: 'root' })
+export class TypeaheadService {
+  createTypaheadConfig<T>(
+    fetch: (term: string) => Observable<TypeaheadItem[]>,
+  ): TypeaheadConfig {
+    const options: TypeaheadItem[] = [];
+    let loading = false;
+
+    return {
+      options,
+      loading,
+      onSearch: (term) => {
+        loading = true;
+        fetch(term).subscribe(res => {
+          options.splice(0, options.length, ...res);
+          loading = false;
+        });
+      },
+    };
+  }
+}

--- a/src/app/features/academic-program/academic-program.models.ts
+++ b/src/app/features/academic-program/academic-program.models.ts
@@ -1,0 +1,33 @@
+import { PaginationQuery } from "@/core/models/pagination-query.model";
+import { Faculty } from "../faculty/faculty.models";
+
+export interface AcademicProgram {
+    _id: string;
+    name: string;
+    description: string;
+    faculty: Faculty;
+    coordinatorName: string;
+    coordinatorEmail: string;
+    createdAt: Date;
+}
+
+export interface AcademicProgramFilter extends PaginationQuery {
+    name?: string;
+    faculty?: string;
+}
+
+export interface CreateAcademicProgramRequest {
+    name: string;
+    description: string;
+    faculty: string;
+    coordinatorName: string;
+    coordinatorEmail: string;
+}
+
+export interface UpdateAcademicProgramRequest {
+    name?: string;
+    description?: string;
+    faculty?: string;
+    coordinatorName?: string;
+    coordinatorEmail?: string;
+}

--- a/src/app/features/academic-program/components/academic-program-form/academic-program-form.component.html
+++ b/src/app/features/academic-program/components/academic-program-form/academic-program-form.component.html
@@ -1,0 +1,3 @@
+<app-dynamic-form [dynamicFormConfig]="academicProgramFormConfig" [isLoading]="isLoading"
+(submitted)="onFormSubmit($event)">
+</app-dynamic-form>

--- a/src/app/features/academic-program/components/academic-program-form/academic-program-form.component.spec.ts
+++ b/src/app/features/academic-program/components/academic-program-form/academic-program-form.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AcademicProgramFormComponent } from './academic-program-form.component';
+
+describe('AcademicProgramFormComponent', () => {
+  let component: AcademicProgramFormComponent;
+  let fixture: ComponentFixture<AcademicProgramFormComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AcademicProgramFormComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(AcademicProgramFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/academic-program/components/academic-program-form/academic-program-form.component.ts
+++ b/src/app/features/academic-program/components/academic-program-form/academic-program-form.component.ts
@@ -1,0 +1,97 @@
+import { Component, Input, OnChanges, OnInit } from '@angular/core';
+import { AcademicProgram, CreateAcademicProgramRequest, UpdateAcademicProgramRequest } from '../../academic-program.models';
+import { DynacmicFormConfig } from '@/shared/components/organisms/dynamic-form/dynamic.form.models';
+import { FormSubmitComponent } from '@/shared/abstracts/form-submit.abstract';
+import { ModalRef } from '@/shared/components/organisms/modal/modal.ref';
+import { AcademicProgramService } from '../../services/academic-program.service';
+import { Validators } from '@angular/forms';
+import { FormFieldType } from '@/shared/models/form-field-type.enum';
+import { Observable } from 'rxjs';
+import { DynamicFormComponent } from "@organisms/dynamic-form/dynamic-form.component";
+import { FacultyService } from '@/features/faculty/services/faculty.service';
+import { TypeaheadService } from '@/core/services/typeahead.service';
+
+@Component({
+  selector: 'app-academic-program-form',
+  standalone: true,
+  imports: [DynamicFormComponent],
+  templateUrl: './academic-program-form.component.html',
+  styleUrl: './academic-program-form.component.scss'
+})
+export class AcademicProgramFormComponent extends FormSubmitComponent<CreateAcademicProgramRequest | UpdateAcademicProgramRequest, AcademicProgram> implements OnInit, OnChanges {
+
+  @Input() academicProgram!: AcademicProgram | null;
+  academicProgramFormConfig!: DynacmicFormConfig;
+
+  constructor(
+    private academicProgramService: AcademicProgramService,
+    private facultyService: FacultyService,
+    private typeaheadService: TypeaheadService,
+    private modalRef: ModalRef) {
+    super();
+  }
+
+  ngOnInit(): void {
+    this.updateFormConfig();
+  }
+
+  ngOnChanges(): void {
+    this.updateFormConfig();
+  }
+
+  private updateFormConfig(): void {
+    this.academicProgramFormConfig = {
+      title: this.academicProgram ? 'Editar programa académico' : 'Crear programa académico',
+      buttonLabel: this.academicProgram ? 'Guardar cambios' : 'Crear programa académico',
+      sections: [
+        {
+          fields: [
+            {
+              key: 'name',
+              label: 'Nombre',
+              value: this.academicProgram?.name,
+              type: FormFieldType.TEXT,
+              placeholder: 'Nombre del programa académico',
+              validators: [Validators.required]
+            },
+            {
+              key: 'description',
+              label: 'Descripción',
+              value: this.academicProgram?.description,
+              type: FormFieldType.TEXT,
+              placeholder: 'Breve descripción',
+              validators: [Validators.required]
+            },
+            {
+              key: 'facultyName',
+              label: 'Facultad',
+              type: FormFieldType.TYPEAHEAD,
+              placeholder: 'Busca una facultad...',
+              typeaheadConfig: this.typeaheadService.createTypaheadConfig(
+                (term) => this.facultyService.getTypeaheadFaculties(term),
+              ),
+              validators: [Validators.required]
+            }
+          ]
+        }
+      ]
+    };
+  }
+
+  override submitData(data: CreateAcademicProgramRequest | UpdateAcademicProgramRequest): Observable<AcademicProgram> {
+    if (this.academicProgram) {
+      return this.academicProgramService.updateAcademicProgram(this.academicProgram._id, data as UpdateAcademicProgramRequest);
+    } else {
+      return this.academicProgramService.createAcademicProgram(data as CreateAcademicProgramRequest);
+    }
+  }
+
+  override onSuccess(): void {
+    this.modalRef.close(true);
+  }
+
+  onFormSubmit(formValue: CreateAcademicProgramRequest | UpdateAcademicProgramRequest): void {
+    this.submitForm(formValue);
+  }
+
+}

--- a/src/app/features/academic-program/components/academic-program-table/academic-program-table.component.html
+++ b/src/app/features/academic-program/components/academic-program-table/academic-program-table.component.html
@@ -1,0 +1,6 @@
+<app-data-table
+  [pageData]="pageData"
+  [columns]="columns"
+  [actions]="actions"
+  [loading]="isLoading"
+  (paginationChange)="onPaginationChange($event)"/>

--- a/src/app/features/academic-program/components/academic-program-table/academic-program-table.component.spec.ts
+++ b/src/app/features/academic-program/components/academic-program-table/academic-program-table.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AcademicProgramTableComponent } from './academic-program-table.component';
+
+describe('AcademicProgramTableComponent', () => {
+  let component: AcademicProgramTableComponent;
+  let fixture: ComponentFixture<AcademicProgramTableComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AcademicProgramTableComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(AcademicProgramTableComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/academic-program/components/academic-program-table/academic-program-table.component.ts
+++ b/src/app/features/academic-program/components/academic-program-table/academic-program-table.component.ts
@@ -1,0 +1,71 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { AcademicProgram, AcademicProgramFilter } from '../../academic-program.models';
+import { ColumnConfig, TableRowAction } from '@/shared/components/organisms/data-table/data-table.models';
+import { DataTableComponent } from '@/shared/components/organisms/data-table/data-table.component';
+import { AcademicProgramService } from '../../services/academic-program.service';
+import { PaginatedResult } from '@/core/models/paginated-result.model';
+import { Observable } from 'rxjs';
+import { TableAction } from '@/shared/models/table-actions.enum';
+import { ModalService } from '@/core/services/modal.service';
+import { DEFAULT_QUERY_PAGINATION } from '@/core/constants/pagination.constants';
+import { AcademicProgramFormComponent } from '../academic-program-form/academic-program-form.component';
+import { DataTable } from '@/shared/abstracts/data-table.abstract';
+
+@Component({
+  selector: 'app-academic-program-table',
+  standalone: true,
+  imports: [DataTableComponent],
+  templateUrl: './academic-program-table.component.html',
+  styleUrl: './academic-program-table.component.scss'
+})
+export class AcademicProgramTableComponent extends DataTable<AcademicProgram, AcademicProgramFilter> implements OnInit {
+  override entityName = 'Programa Académico';
+  override entityKeyName = 'academicProgram';
+  override formComponent = AcademicProgramFormComponent;
+  @Input() override allowedActions = [TableAction.EDIT, TableAction.DELETE];
+
+  readonly columns: ColumnConfig<AcademicProgram>[] = [
+    { label: 'Nombre', field: 'name', sortable: true },
+    { label: 'Descripción', field: 'description', sortable: true },
+    {
+      label: 'Facultad',
+      field: 'faculty',
+      sortable: true,
+      cell: (program) => program.faculty.name
+    },
+    {
+      label: 'Coordinador',
+      field: 'coordinatorName',
+      sortable: true,
+      cell: (program) => `${program.coordinatorName} (${program.coordinatorEmail})`
+    }
+  ];
+
+  constructor(private academicProgramService: AcademicProgramService, modalService: ModalService) {
+    super(modalService);
+  }
+
+  ngOnInit(): void {
+    this.loadPageData(this.getInitialFilter());
+  }
+
+  reloadPageData(): void {
+    this.loadPageData(this.filter);
+  }
+
+  override getAll(filter: AcademicProgramFilter): Observable<PaginatedResult<AcademicProgram>> {
+    return this.academicProgramService.getAcademicPrograms(filter);
+  }
+
+  override delete(id: string): Observable<void> {
+    return this.academicProgramService.deleteAcademicProgram(id);
+  }
+
+  override getInitialFilter(): AcademicProgramFilter {
+    return { ...DEFAULT_QUERY_PAGINATION };
+  }
+
+  get actions(): TableRowAction<AcademicProgram>[] {
+    return this.getTableActions();
+  }
+}

--- a/src/app/features/academic-program/services/academic-program.service.spec.ts
+++ b/src/app/features/academic-program/services/academic-program.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AcademicProgramService } from './academic-program.service';
+
+describe('AcademicProgramService', () => {
+  let service: AcademicProgramService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AcademicProgramService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/features/academic-program/services/academic-program.service.ts
+++ b/src/app/features/academic-program/services/academic-program.service.ts
@@ -1,0 +1,35 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { AcademicProgram, AcademicProgramFilter, CreateAcademicProgramRequest, UpdateAcademicProgramRequest } from '../academic-program.models';
+import { Observable } from 'rxjs';
+import { PaginatedResult } from '@/core/models/paginated-result.model';
+import { API_ENDPOINTS } from '@/core/constants/api-endpoints.constants';
+import { objectToHttpParams } from '@/core/utils/http-params.util';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AcademicProgramService {
+
+  constructor(
+    private http: HttpClient,
+  ) { }
+
+  createAcademicProgram(createAcademicProgramRequest: CreateAcademicProgramRequest): Observable<AcademicProgram> {
+    return this.http.post<AcademicProgram>(API_ENDPOINTS.ACADEMIC_PROGRAM.CREATE, createAcademicProgramRequest);
+  }
+
+  getAcademicPrograms(academicProgramFilter: AcademicProgramFilter): Observable<PaginatedResult<AcademicProgram>> {
+    const params = objectToHttpParams(academicProgramFilter);
+    return this.http.get<PaginatedResult<AcademicProgram>>(API_ENDPOINTS.ACADEMIC_PROGRAM.GET, { params });
+  }
+
+  updateAcademicProgram(id: string, updateAcademicProgramRequest: UpdateAcademicProgramRequest): Observable<AcademicProgram> {
+    return this.http.put<AcademicProgram>(API_ENDPOINTS.ACADEMIC_PROGRAM.UPDATE(id), updateAcademicProgramRequest);
+  }
+
+  deleteAcademicProgram(id: string): Observable<void> {
+    return this.http.delete<void>(API_ENDPOINTS.ACADEMIC_PROGRAM.DELETE(id));
+  }
+
+}

--- a/src/app/features/admin/admin.constants.ts
+++ b/src/app/features/admin/admin.constants.ts
@@ -4,7 +4,7 @@ import * as LucideIcons from 'lucide-angular';
 
 export const ADMIN_SIDEBAR_ITEMS: SidebarItem[] = [
     { label: 'Facultades', route: ROUTES.ADMIN.FACULTIES, icon: LucideIcons.SwatchBook },
-    { label: 'Calendario', route: '/admin/calendar', icon: LucideIcons.CalendarDays },
+    { label: 'Programas Academicos', route: ROUTES.ADMIN.ACADEMIC_PROGRAMS, icon: LucideIcons.BookType },
     { label: 'Equipos', route: '/admin/teams', icon: LucideIcons.Users },
     { label: 'Configuración', route: '/admin/settings', icon: LucideIcons.Settings },
 ];

--- a/src/app/features/admin/admin.routes.ts
+++ b/src/app/features/admin/admin.routes.ts
@@ -1,4 +1,3 @@
-import { ROUTES } from "@/core/constants/routes.constants";
 import { Routes } from "@angular/router";
 
 export const ADMIN_ROUTES: Routes = [
@@ -10,7 +9,11 @@ export const ADMIN_ROUTES: Routes = [
                 path: 'faculties',
                 loadComponent: () => import('./pages/admin-faculty-page/admin-faculty-page.component').then(m => m.AdminFacultyPageComponent),
 
-            }   
+            },
+            {
+                path: 'academic-programs',
+                loadComponent: () => import('./pages/admin-academic-program-page/admin-academic-program-page.component').then(m => m.AdminAcademicProgramPageComponent),
+            }
 
         ]
     }

--- a/src/app/features/admin/components/admin-sidebar/admin-sidebar.component.scss
+++ b/src/app/features/admin/components/admin-sidebar/admin-sidebar.component.scss
@@ -83,7 +83,7 @@
         @include padding-x(1rem);
         color: $dark-color;
         text-decoration: none;
-        transition: all 0.3s ease;
+        transition: border 0.3s ease;
         font-weight: 500;
 
         &:hover,

--- a/src/app/features/admin/pages/admin-academic-program-page/admin-academic-program-page.component.html
+++ b/src/app/features/admin/pages/admin-academic-program-page/admin-academic-program-page.component.html
@@ -1,0 +1,3 @@
+<app-admin-section-wrapper title="Programas Académicos" description="Gestiona los programas académicos de la institución">
+  <app-academic-program-table />
+</app-admin-section-wrapper>

--- a/src/app/features/admin/pages/admin-academic-program-page/admin-academic-program-page.component.spec.ts
+++ b/src/app/features/admin/pages/admin-academic-program-page/admin-academic-program-page.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AdminAcademicProgramPageComponent } from './admin-academic-program-page.component';
+
+describe('AdminAcademicProgramPageComponent', () => {
+  let component: AdminAcademicProgramPageComponent;
+  let fixture: ComponentFixture<AdminAcademicProgramPageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AdminAcademicProgramPageComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(AdminAcademicProgramPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/admin/pages/admin-academic-program-page/admin-academic-program-page.component.ts
+++ b/src/app/features/admin/pages/admin-academic-program-page/admin-academic-program-page.component.ts
@@ -1,0 +1,14 @@
+import { Component } from '@angular/core';
+import { AdminSectionWrapperComponent } from "../../components/admin-section-wrapper/admin-section-wrapper.component";
+import { AcademicProgramTableComponent } from "../../../academic-program/components/academic-program-table/academic-program-table.component";
+
+@Component({
+  selector: 'app-admin-academic-program-page',
+  standalone: true,
+  imports: [AdminSectionWrapperComponent, AcademicProgramTableComponent],
+  templateUrl: './admin-academic-program-page.component.html',
+  styleUrl: './admin-academic-program-page.component.scss'
+})
+export class AdminAcademicProgramPageComponent {
+
+}

--- a/src/app/features/admin/pages/admin-faculty-page/admin-faculty-page.component.ts
+++ b/src/app/features/admin/pages/admin-faculty-page/admin-faculty-page.component.ts
@@ -1,6 +1,5 @@
 import { Component, ViewChild } from '@angular/core';
 import { AdminSectionWrapperComponent } from '../../components/admin-section-wrapper/admin-section-wrapper.component';
-import { Faculty } from '@/features/faculty/faculty.models';
 import { FacultyTableComponent } from '@/features/faculty/components/faculty-table/faculty-table.component';
 import { TableAction } from '@/shared/models/table-actions.enum';
 import { ButtonComponent } from '@/shared/components/atoms/button/button.component';
@@ -29,7 +28,7 @@ export class AdminFacultyPageComponent {
     }).afterClosed()
       .subscribe((result) => {
         if (result) {
-          this.facultyTable.realoadData();
+          this.facultyTable.reloadPageData();
         }
       });
   }

--- a/src/app/features/faculty/components/faculty-form/faculty-form.component.ts
+++ b/src/app/features/faculty/components/faculty-form/faculty-form.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, Input, OnChanges, OnInit } from '@angular/core';
+import { Component, Input, OnChanges, OnInit } from '@angular/core';
 import { CreateFacultyRequest, Faculty } from '../../faculty.models';
 import { DynamicFormComponent } from '@/shared/components/organisms/dynamic-form/dynamic-form.component';
 import { Validators, ReactiveFormsModule } from '@angular/forms';
@@ -21,17 +21,16 @@ import { FACULTY_MIN_DESCRIPTION_LENGTH, FACULTY_MIN_NAME_LENGTH } from '../../f
 })
 export class FacultyFormComponent extends FormSubmitComponent<Partial<Faculty>, Faculty> implements OnInit, OnChanges {
   @Input() faculty!: Faculty | null;
+  facultyFormConfig!: DynacmicFormConfig;
 
   constructor(private facultyService: FacultyService, private modalRef: ModalRef) {
     super();
   }
 
- facultyFormConfig!: DynacmicFormConfig;
-
   ngOnInit(): void {
     this.updateFormConfig();
   }
-  
+
   ngOnChanges(): void {
     this.updateFormConfig();
   }

--- a/src/app/features/faculty/components/faculty-table/faculty-table.component.ts
+++ b/src/app/features/faculty/components/faculty-table/faculty-table.component.ts
@@ -1,18 +1,15 @@
 import { PaginatedResult } from '@/core/models/paginated-result.model';
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { Faculty, FacultyFilter } from '../../faculty.models';
 import { ColumnConfig, TableRowAction } from '@/shared/components/organisms/data-table/data-table.models';
-import { Edit, Trash } from 'lucide-angular';
 import { DataTableComponent } from '@/shared/components/organisms/data-table/data-table.component';
-import { RetrievePaginatedData } from '@/shared/abstracts/retrieve-paginated-data';
 import { FacultyService } from '../../services/faculty.service';
 import { Observable } from 'rxjs';
-import { DEFAULT_QUERY_PAGINATION } from '@/core/constants/pagination.constants';
 import { TableAction } from '@/shared/models/table-actions.enum';
 import { ModalService } from '@/core/services/modal.service';
 import { FacultyFormComponent } from '../faculty-form/faculty-form.component';
-import { ConfirmDialogComponent } from '@/shared/components/molecules/confirm-dialog/confirm-dialog.component';
-import { PaginationQuery } from '@/core/models/pagination-query.model';
+
+import { DataTable } from '@/shared/abstracts/data-table.abstract';
 
 @Component({
   selector: 'app-faculty-table',
@@ -21,90 +18,40 @@ import { PaginationQuery } from '@/core/models/pagination-query.model';
   templateUrl: './faculty-table.component.html',
   styleUrl: './faculty-table.component.scss'
 })
-export class FacultyTableComponent extends RetrievePaginatedData<Faculty, FacultyFilter> implements OnInit {
-  @Input() allowedActions?: TableAction[];
-  override filter: FacultyFilter = DEFAULT_QUERY_PAGINATION;
+export class FacultyTableComponent extends DataTable<Faculty, FacultyFilter> implements OnInit {
+  override entityName = 'Facultad';
+  override entityKeyName = 'faculty';
+  override formComponent = FacultyFormComponent;
+  @Input() override allowedActions = [TableAction.EDIT, TableAction.DELETE];
+
   readonly columns: ColumnConfig<Faculty>[] = [
     { label: 'Nombre', field: 'name', sortable: true },
     { label: 'Descripción', field: 'description', sortable: true },
     { label: 'Decano', cell: (f) => `${f.deanName} (${f.deanEmail})` }
   ];
 
-  constructor(private facultyService: FacultyService, private modalService: ModalService) {
-    super();
+  constructor(private facultyService: FacultyService, modalService: ModalService) {
+    super(modalService);
   }
 
   ngOnInit(): void {
     this.loadPageData(this.filter);
   }
 
-  get actions(): TableRowAction<Faculty>[] {
-    const list: TableRowAction<Faculty>[] = [];
-
-    if (this.allowedActions?.includes(TableAction.EDIT)) {
-      list.push({
-        label: 'Editar',
-        icon: Edit,
-        action: (faculty) => this.editFaculty(faculty)
-      });
-    }
-
-    if (this.allowedActions?.includes(TableAction.DELETE)) {
-      list.push({
-        label: 'Eliminar',
-        icon: Trash,
-        danger: true,
-        action: (faculty) => this.deleteFaculty(faculty)
-      });
-    }
-
-    return list;
-  }
-
-  realoadData(): void {
+  reloadPageData(): void {
     this.loadPageData(this.filter);
   }
 
-  override fetchPage(filter: FacultyFilter): Observable<PaginatedResult<Faculty>> {
+  override getAll(filter: FacultyFilter): Observable<PaginatedResult<Faculty>> {
     return this.facultyService.getFaculties(filter);
   }
 
-  onPaginationChange(query: PaginationQuery): void {
-    this.loadPageData({...this.filter, ...query });
+  override delete(id: string): Observable<void> {
+    return this.facultyService.deleteFaculty(id);
   }
 
-  private editFaculty(faculty: Faculty): void {
-    this.modalService.open(FacultyFormComponent, {
-      data: {
-        faculty
-      }
-    }).afterClosed()
-      .subscribe((result) => {
-        if (result) {
-          this.loadPageData(this.filter);
-        }
-      });
+  get actions(): TableRowAction<Faculty>[] {
+    return this.getTableActions();
   }
 
-  private deleteFaculty(faculty: Faculty): void {
-    this.modalService
-      .open(ConfirmDialogComponent, {
-        data: {
-          confirmDialogData: {
-            title: '¿Eliminar facultad?',
-            message: `¿Estás seguro de eliminar la facultad "${faculty.name}"?`,
-            confirmText: 'Eliminar',
-            cancelText: 'Cancelar',
-            danger: true
-          }
-
-        }
-      })
-      .afterClosed()
-      .subscribe((confirmed) => {
-        if (confirmed) {
-          this.facultyService.deleteFaculty(faculty._id).subscribe(() => this.realoadData());
-        }
-      });
-  }
 }

--- a/src/app/features/faculty/services/faculty.service.ts
+++ b/src/app/features/faculty/services/faculty.service.ts
@@ -1,10 +1,11 @@
 import { HttpClient } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { Injectable, Type } from '@angular/core';
 import { Observable } from 'rxjs';
 import { CreateFacultyRequest, Faculty, FacultyFilter, UpdateFacultyRequest } from '../faculty.models';
 import { PaginatedResult } from '@/core/models/paginated-result.model';
 import { API_ENDPOINTS } from '@/core/constants/api-endpoints.constants';
 import { objectToHttpParams } from '@/core/utils/http-params.util';
+import { TypeaheadItem } from '@/shared/models/typeahead-item.model';
 
 @Injectable({
   providedIn: 'root'
@@ -16,6 +17,12 @@ export class FacultyService {
   getFaculties(filter: FacultyFilter): Observable<PaginatedResult<Faculty>> {
     const params = objectToHttpParams(filter);
     return this.http.get<PaginatedResult<Faculty>>(API_ENDPOINTS.FACULTY.GET, { params });
+  }
+
+  getTypeaheadFaculties(query: string): Observable<TypeaheadItem[]> {
+    return this.http.get<TypeaheadItem[]>(API_ENDPOINTS.FACULTY.GET_TYPEAHEAD, {
+      params: { query }
+    });
   }
 
   createFaculty(createFacultyRequest: CreateFacultyRequest): Observable<Faculty> {

--- a/src/app/shared/abstracts/data-table.abstract.ts
+++ b/src/app/shared/abstracts/data-table.abstract.ts
@@ -1,0 +1,88 @@
+import { RetrievePaginatedData } from './retrieve-paginated-data';
+import { PaginationQuery } from '@/core/models/pagination-query.model';
+import { PaginatedResult } from '@/core/models/paginated-result.model';
+import { ModalService } from '@/core/services/modal.service';
+import { ConfirmDialogComponent } from '@/shared/components/molecules/confirm-dialog/confirm-dialog.component';
+import { Observable } from 'rxjs';
+import { Type } from '@angular/core';
+import { TableAction } from '../models/table-actions.enum';
+import { TableRowAction } from '../components/organisms/data-table/data-table.models';
+import { Edit, Trash } from 'lucide-angular';
+import { DEFAULT_QUERY_PAGINATION } from '@/core/constants/pagination.constants';
+
+export abstract class DataTable<T extends { _id: string }, U extends PaginationQuery = PaginationQuery> extends RetrievePaginatedData<T, U> {
+    abstract entityKeyName: string;
+    abstract entityName: string;
+    abstract formComponent: Type<any>;
+    allowedActions: TableAction[] = [];
+
+    constructor(protected modalService: ModalService) {
+        super();
+    }
+
+    abstract getAll(filter: U): Observable<PaginatedResult<T>>;
+    abstract delete(id: string): Observable<void>;
+
+    override fetchPage(filter: U): Observable<PaginatedResult<T>> {
+        return this.getAll(filter);
+    }
+
+    override getInitialFilter(): U {
+        return { ...DEFAULT_QUERY_PAGINATION } as U;
+    }
+
+    onPaginationChange(query: PaginationQuery): void {
+        this.loadPageData({ ...this.filter, ...query });
+    }
+
+    protected editEntity(entity: T): void {
+        this.modalService
+            .open(this.formComponent, { data: { [this.entityKeyName]: entity } })
+            .afterClosed()
+            .subscribe((result) => result && this.loadPageData(this.filter));
+    }
+
+    protected deleteEntity(entity: T & { name?: string }): void {
+        this.modalService
+            .open(ConfirmDialogComponent, {
+                data: {
+                    confirmDialogData: {
+                        title: `¿Eliminar ${this.entityName}?`,
+                        message: `¿Estás seguro de eliminar "${entity.name ?? 'este registro'}"?`,
+                        confirmText: 'Eliminar',
+                        cancelText: 'Cancelar',
+                        danger: true
+                    }
+                }
+            })
+            .afterClosed()
+            .subscribe((confirmed) => {
+                if (confirmed) {
+                    this.delete(entity._id).subscribe(() => this.loadPageData(this.filter));
+                }
+            });
+    }
+
+    protected getTableActions(): TableRowAction<T>[] {
+        const actions: TableRowAction<T>[] = [];
+
+        if (this.allowedActions?.includes(TableAction.EDIT)) {
+            actions.push({
+                label: 'Editar',
+                icon: Edit,
+                action: (entity) => this.editEntity(entity)
+            });
+        }
+
+        if (this.allowedActions?.includes(TableAction.DELETE)) {
+            actions.push({
+                label: 'Eliminar',
+                icon: Trash,
+                danger: true,
+                action: (entity) => this.deleteEntity(entity)
+            });
+        }
+
+        return actions;
+    }
+}

--- a/src/app/shared/abstracts/retrieve-paginated-data.ts
+++ b/src/app/shared/abstracts/retrieve-paginated-data.ts
@@ -6,6 +6,10 @@ export abstract class RetrievePaginatedData<T, U extends PaginationQuery = Pagin
   isLoading = false;
   pageData!: PaginatedResult<T>;
   protected filter!: U;
+  
+  constructor() {
+    this.filter = this.getInitialFilter();
+  }
 
   loadPageData(filter: U): void {
     this.isLoading = true;
@@ -31,6 +35,7 @@ export abstract class RetrievePaginatedData<T, U extends PaginationQuery = Pagin
       limit: filter.limit
     };
   }
+  protected abstract getInitialFilter(): U;
 
   protected abstract fetchPage(filter: U): Observable<PaginatedResult<T>>;
 }

--- a/src/app/shared/components/atoms/input-typeahead/input-typeahead.component.html
+++ b/src/app/shared/components/atoms/input-typeahead/input-typeahead.component.html
@@ -1,0 +1,25 @@
+<div class="input-typeahead">
+  <input
+    [id]="id"
+    class="input-typeahead__input"
+    type="text"
+    [value]="displayLabel"
+    (input)="onInput($event)"
+    [placeholder]="config.placeholder"
+    autocomplete="off"
+  />
+
+  <div class="input-typeahead__dropdown" *ngIf="showDropdown && config.options.length">
+    <div
+      class="input-typeahead__option"
+      *ngFor="let option of config.options"
+      (click)="selectOption(option)"
+    >
+      {{ option.label }}
+    </div>
+  </div>
+
+  <div class="input-typeahead__loading" *ngIf="config.loading">
+    Cargando...
+  </div>
+</div>

--- a/src/app/shared/components/atoms/input-typeahead/input-typeahead.component.scss
+++ b/src/app/shared/components/atoms/input-typeahead/input-typeahead.component.scss
@@ -1,0 +1,37 @@
+.input-typeahead {
+  position: relative;
+
+  &__input {
+    width: 100%;
+    padding: 0.5rem;
+    border-radius: 4px;
+    border: 1px solid #ccc;
+  }
+
+  &__dropdown {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    width: 100%;
+    background: white;
+    border: 1px solid #ccc;
+    max-height: 200px;
+    overflow-y: auto;
+    z-index: 10;
+  }
+
+  &__option {
+    padding: 0.5rem;
+    cursor: pointer;
+
+    &:hover {
+      background: #f4f4f4;
+    }
+  }
+
+  &__loading {
+    font-size: 0.75rem;
+    margin-top: 0.25rem;
+    color: gray;
+  }
+}

--- a/src/app/shared/components/atoms/input-typeahead/input-typeahead.component.spec.ts
+++ b/src/app/shared/components/atoms/input-typeahead/input-typeahead.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { InputTypeaheadComponent } from './input-typeahead.component';
+
+describe('InputTypeaheadComponent', () => {
+  let component: InputTypeaheadComponent;
+  let fixture: ComponentFixture<InputTypeaheadComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [InputTypeaheadComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(InputTypeaheadComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/atoms/input-typeahead/input-typeahead.component.ts
+++ b/src/app/shared/components/atoms/input-typeahead/input-typeahead.component.ts
@@ -1,0 +1,43 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { TypeaheadConfig, TypeaheadItem } from '@/shared/models/typeahead-item.model';
+
+@Component({
+  selector: 'app-input-typeahead',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './input-typeahead.component.html',
+  styleUrl: './input-typeahead.component.scss'
+})
+export class InputTypeaheadComponent implements OnInit {
+  @Input() control!: FormControl;
+  @Input() id = '';
+  @Input() config!: TypeaheadConfig;
+
+  displayLabel = '';
+  showDropdown = false;
+
+  ngOnInit(): void {
+    const selectedValue = this.control.value;
+    const selected = this.config.options?.find(o => o.value === selectedValue);
+    this.displayLabel = selected?.label ?? '';
+  }
+
+  onInput(event: Event): void {
+    const term = (event.target as HTMLInputElement).value;
+    this.displayLabel = term;
+
+    this.showDropdown = true;
+
+    if (this.config.onSearch) {
+      this.config.onSearch(term);
+    }
+  }
+
+  selectOption(option: TypeaheadItem): void {
+    this.control.setValue(option.value);       
+    this.displayLabel = option.label;            
+    this.showDropdown = false;
+  }
+}

--- a/src/app/shared/components/molecules/input-form-row/input-form-row.component.html
+++ b/src/app/shared/components/molecules/input-form-row/input-form-row.component.html
@@ -5,6 +5,7 @@
     <app-input-text *ngSwitchCase="'text'" [control]="control" [id]="id" [placeholder]="placeholder" />
     <app-input-number *ngSwitchCase="'number'" [control]="control" [id]="id" [placeholder]="placeholder" />
     <app-input-password *ngSwitchCase="'password'" [control]="control" [id]="id" [placeholder]="placeholder" />
+    <app-input-typeahead *ngSwitchCase="'typeahead'" [control]="control" [id]="id" [config]="typeaheadConfig!" />
   </ng-container>
 
   <div class="input-form-row__error" [class.input-form-row__error--visible]="showError">

--- a/src/app/shared/components/molecules/input-form-row/input-form-row.component.ts
+++ b/src/app/shared/components/molecules/input-form-row/input-form-row.component.ts
@@ -5,6 +5,8 @@ import { InputTextComponent } from '../../atoms/input-text/input-text.component'
 import { InputNumberComponent } from '../../atoms/input-number/input-number.component';
 import { InputPasswordComponent } from '../../atoms/input-password/input-password.component';
 import { FormFieldType } from '@/shared/models/form-field-type.enum';
+import { TypeaheadConfig } from '@/shared/models/typeahead-item.model';
+import { InputTypeaheadComponent } from "../../atoms/input-typeahead/input-typeahead.component";
 
 @Component({
   selector: 'app-input-form-row',
@@ -13,8 +15,9 @@ import { FormFieldType } from '@/shared/models/form-field-type.enum';
     InputTextComponent,
     InputNumberComponent,
     InputPasswordComponent,
-    CommonModule
-  ],
+    CommonModule,
+    InputTypeaheadComponent
+],
   templateUrl: './input-form-row.component.html',
   styleUrl: './input-form-row.component.scss'
 })
@@ -24,6 +27,7 @@ export class InputFormRowComponent {
   @Input() label = '';
   @Input() placeholder = '';
   @Input() type: FormFieldType = FormFieldType.TEXT;
+  @Input() typeaheadConfig?: TypeaheadConfig;
 
   get showError(): boolean {
     return this.control.invalid && (this.control.dirty || this.control.touched);

--- a/src/app/shared/components/organisms/dynamic-form/dynamic-form.component.html
+++ b/src/app/shared/components/organisms/dynamic-form/dynamic-form.component.html
@@ -7,7 +7,7 @@
 
     <ng-container *ngFor="let field of section.fields">
       <app-input-form-row [control]="getFormControl(field.key)" [id]="field.key" [label]="field.label"
-        [placeholder]="field.placeholder || ''" [type]="field.type" />
+        [placeholder]="field.placeholder || ''" [type]="field.type" [typeaheadConfig]="field.typeaheadConfig" />
     </ng-container>
   </ng-container>
 

--- a/src/app/shared/components/organisms/dynamic-form/dynamic.form.models.ts
+++ b/src/app/shared/components/organisms/dynamic-form/dynamic.form.models.ts
@@ -1,4 +1,5 @@
 import { FormFieldType } from '@/shared/models/form-field-type.enum';
+import { TypeaheadConfig } from '@/shared/models/typeahead-item.model';
 import { ValidatorFn } from '@angular/forms';
 
 
@@ -12,10 +13,11 @@ export interface FormField {
   label: string;
   type: FormFieldType;
   placeholder?: string;
-  options?: FieldOption[]; 
+  options?: FieldOption[];
   validators?: ValidatorFn[];
   disabled?: boolean;
   value?: string | number | boolean;
+  typeaheadConfig?: TypeaheadConfig;
 }
 
 export interface FormFieldSection {

--- a/src/app/shared/models/form-field-type.enum.ts
+++ b/src/app/shared/models/form-field-type.enum.ts
@@ -3,4 +3,5 @@ export enum FormFieldType {
     NUMBER = 'number',
     PASSWORD = 'password',
     EMAIL = 'email',
+    TYPEAHEAD = 'typeahead',
 } 

--- a/src/app/shared/models/typeahead-item.model.ts
+++ b/src/app/shared/models/typeahead-item.model.ts
@@ -1,0 +1,12 @@
+export interface TypeaheadItem<T = string> {
+    value: T;
+    label: string;
+}
+
+export interface TypeaheadConfig {
+  placeholder?: string;
+  loading?: boolean;
+  options: TypeaheadItem[];
+  onSearch?: (term: string) => void;
+  onSelect?: (item: TypeaheadItem) => void;
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -7,6 +7,7 @@
     box-sizing: border-box;
     margin: 0;
     padding: 0;
+    font-family: 'Poppins', sans-serif;
 }
 
 html {
@@ -15,7 +16,6 @@ html {
 }
 
 body {
-    font-family: 'Poppins', sans-serif;
     background-color: $light-color;
     line-height: 1.6;
     -webkit-font-smoothing: antialiased;
@@ -24,9 +24,8 @@ body {
     color: $dark-color;
 }
 
-input, 
-select, textarea {
-    font-family: 'Poppins', sans-serif;
+input,
+select,
+textarea {
     color: $dark-color;
 }
-


### PR DESCRIPTION
This pull request introduces a new feature for managing academic programs in the application. It includes updates to the API endpoints and routing, the addition of new models, services, and components for academic programs, and enhancements to the admin interface. Below are the most important changes grouped by theme:

### API and Routing Updates
* Added new API endpoints for academic programs, including `GET`, `CREATE`, `UPDATE`, and `DELETE` operations in `api-endpoints.constants.ts`.
* Updated admin routes to include a path for academic programs and lazy-loaded the relevant component.

### Academic Program Feature Implementation
* Created models for academic programs, including `AcademicProgram`, `AcademicProgramFilter`, and request models for creating and updating academic programs in `academic-program.models.ts`.
* Added a service (`academic-program.service.ts`) to handle API interactions for academic programs, including CRUD operations.
* Developed a form component (`academic-program-form.component.ts`) to handle the creation and editing of academic programs, with dynamic form configuration and typeahead integration for faculty selection.
* Built a table component (`academic-program-table.component.ts`) to display a paginated list of academic programs with sorting, filtering, and row actions (edit/delete).

### Admin Interface Enhancements
* Updated the admin sidebar to include a navigation link for academic programs.
* Added a new admin page (`admin-academic-program-page.component.html`) for managing academic programs, which wraps the table component in a section layout.

### Testing
* Added unit tests for the new `TypeaheadService`, `AcademicProgramService`, `AcademicProgramFormComponent`, and `AcademicProgramTableComponent` to ensure functionality and reliability. [[1]](diffhunk://#diff-de2cad958008b3228cf428f4e0cbdb44d55a5039cd8816f290e574507062b8c2R1-R16) [[2]](diffhunk://#diff-b7d1dfde39c44ad0dbdebcf8cfe64c2470710d54012375a35daf5be3bca6a3bbR1-R16) [[3]](diffhunk://#diff-1fafb97ebf60961823896ad9f459e037528460b6b21c285b663e4a4df8d4090aR1-R23) [[4]](diffhunk://#diff-163d958383abfb6892619cec673e2af6c3fc49a4a1bf8d9258f31897e87bba36R1-R23)